### PR TITLE
fix:  Windows spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In order for this extension to compile and run any code, you will need to have t
 
 Examples:
 
-- Rust: `rustup target add wasm32-wasi`
+- Rust: `rustup target add wasm32-wasip1`
 - Javascript: `npm install --save-dev @gcoredev/fastedge-sdk-js`
 
 More detail can be found in the SDK documentation above. 👆

--- a/exampleFolder/package-lock.json
+++ b/exampleFolder/package-lock.json
@@ -8,7 +8,7 @@
       "name": "extension-playground",
       "version": "1.0.0",
       "devDependencies": {
-        "@gcoredev/fastedge-sdk-js": "^1.1.1",
+        "@gcoredev/fastedge-sdk-js": "^1.1.2",
         "typescript": "^5.4.5"
       }
     },
@@ -735,9 +735,9 @@
       }
     },
     "node_modules/@gcoredev/fastedge-sdk-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@gcoredev/fastedge-sdk-js/-/fastedge-sdk-js-1.1.1.tgz",
-      "integrity": "sha512-oU+8y1zIFSqDOvUoSeTweU25b+ssk5EmNe6hzsowRqOgbcR4XpDJlj7BBQQCYV+INGJz3C89flsT5GlRZcghEw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@gcoredev/fastedge-sdk-js/-/fastedge-sdk-js-1.1.2.tgz",
+      "integrity": "sha512-nqrsyqTTa9stEyGcidylSzdlqihOmfXxZ7uPaXALY53jaJVh4PTXFscuLI99HxeSn1K47dZlsjH0ruNnTdpvXg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/exampleFolder/package.json
+++ b/exampleFolder/package.json
@@ -10,7 +10,8 @@
   "type": "module",
   "author": "Gordon Farquharson",
   "devDependencies": {
-    "@gcoredev/fastedge-sdk-js": "^1.1.1",
+    "@gcoredev/fastedge-sdk-js": "^1.1.2",
     "typescript": "^5.4.5"
-  }
+  },
+  "dependencies": {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "fastedge",
       "version": "0.2.0",
       "dependencies": {
+        "toml": "^3.0.0",
+        "tree-kill": "^1.2.2",
         "vscode-debugadapter": "^1.51.0",
         "vscode-debugprotocol": "^1.51.0"
       },
@@ -4110,6 +4112,21 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -150,6 +150,8 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "toml": "^3.0.0",
+    "tree-kill": "^1.2.2",
     "vscode-debugadapter": "^1.51.0",
     "vscode-debugprotocol": "^1.51.0"
   }

--- a/src/FastEdgeDebugSession.ts
+++ b/src/FastEdgeDebugSession.ts
@@ -1,17 +1,20 @@
+import * as os from "os";
 import * as vscode from "vscode";
-import * as cp from "child_process";
+import treeKill from "tree-kill";
+import { DebugProtocol } from "vscode-debugprotocol";
 import {
   DebugSession,
   OutputEvent,
   TerminatedEvent,
 } from "vscode-debugadapter";
-import { DebugProtocol } from "vscode-debugprotocol";
+import { spawn, ChildProcess } from "child_process";
+
 import { DebugConfig } from "./BinaryDebugConfigurationProvider";
 
 import { compileActiveEditorsBinary } from "./compiler";
 
 export class FastEdgeDebugSession extends DebugSession {
-  private childProcess: cp.ChildProcess | undefined;
+  private childProcess: ChildProcess | undefined;
   private breakpoints: vscode.Breakpoint[] = [];
   private disabledBreakpoints: vscode.Breakpoint[] = [];
 
@@ -168,22 +171,27 @@ export class FastEdgeDebugSession extends DebugSession {
       execArgs.push(...this.injectVariables("env", args.env));
     }
 
-    this.childProcess = cp.spawn(cli, execArgs, {
+    const isWindows = os.platform() === "win32";
+    const shell = isWindows ? "cmd.exe" : "sh";
+
+    this.childProcess = spawn(cli, execArgs, {
+      shell,
+      stdio: ["ignore", "pipe", "pipe"],
       env: {
         RUST_LOG: loggingLevel,
         ...process.env, // Preserve existing environment variables
       },
     });
 
-    this.childProcess?.stdout?.on("data", (data) => {
+    this.childProcess?.stdout?.on("data", (data: Buffer) => {
       this.logDebugConsole(data.toString(), "stdout");
     });
 
-    this.childProcess?.stderr?.on("data", (data) => {
+    this.childProcess?.stderr?.on("data", (data: Buffer) => {
       this.logDebugConsole(data.toString(), "stderr");
     });
 
-    this.childProcess?.on("close", (code) => {
+    this.childProcess?.on("close", (code: number) => {
       this.sendEvent(new TerminatedEvent());
     });
 
@@ -209,7 +217,7 @@ export class FastEdgeDebugSession extends DebugSession {
     for (const key in vars) {
       result.push(
         type === "env" ? "--env" : "--headers",
-        `${key}=${vars[key]}`
+        `"${key}=${vars[key]}"`
       );
     }
     return result;
@@ -220,7 +228,11 @@ export class FastEdgeDebugSession extends DebugSession {
     args: DebugProtocol.DisconnectArguments
   ): void {
     if (this.childProcess) {
-      this.childProcess.kill();
+      if (this.childProcess?.pid) {
+        treeKill(this.childProcess.pid);
+      } else {
+        this.childProcess.kill();
+      }
       this.childProcess = undefined;
     }
     // Remove all disabled breakpoints
@@ -228,7 +240,7 @@ export class FastEdgeDebugSession extends DebugSession {
     // Add original breakpoints
     vscode.debug.addBreakpoints(this.breakpoints);
 
-    this.logDebugConsole("FastEdge App stopping...");
+    this.logDebugConsole("FastEdge App stopping...\n");
     this.sendResponse(response);
   }
 }

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import path from "node:path";
 
 import { compileJavascriptBinary } from "./jsBuild";
 import { compileRustAndFindBinary } from "./rustBuild";
@@ -45,11 +46,18 @@ async function compileActiveEditorsBinary(
 
   if (activeFileLanguage === "javascript") {
     return {
-      path: await compileJavascriptBinary(activeFile, debugContext),
+      path: await compileJavascriptBinary(
+        activeFile,
+        debugContext,
+        logDebugConsole
+      ),
       lang: activeFileLanguage,
     };
   } else if (activeFileLanguage === "rust") {
-    const activeFilePath = activeFile?.slice(0, activeFile?.lastIndexOf("/"));
+    const activeFilePath = activeFile?.slice(
+      0,
+      activeFile?.lastIndexOf(path.sep)
+    );
     return {
       path: await compileRustAndFindBinary(activeFilePath, logDebugConsole),
       lang: activeFileLanguage,

--- a/src/compiler/rustBuild.ts
+++ b/src/compiler/rustBuild.ts
@@ -1,23 +1,38 @@
 import { spawn } from "child_process";
+import * as os from "os";
+
 import { LogToDebugConsole } from "./types";
+import { rustConfigWasiTarget } from "./rustConfig";
 
 export function compileRustAndFindBinary(
   activeFilePath: string,
   logDebugConsole: LogToDebugConsole
 ) {
   return new Promise<string>(async (resolve, reject) => {
-    const cargoBuild = spawn("cargo", ["build", "--message-format=json"], {
-      cwd: activeFilePath,
-    });
+    logDebugConsole("Compiling Rust binary...");
+    const isWindows = os.platform() === "win32";
+    const shell = isWindows ? "cmd.exe" : "sh";
+
+    const target = rustConfigWasiTarget(logDebugConsole, activeFilePath);
+    logDebugConsole("wasm build target: " + target, "stderr");
+    const cargoBuild = spawn(
+      "cargo",
+      ["build", "--message-format=json", `--target=${target}`],
+      {
+        shell,
+        stdio: ["ignore", "pipe", "pipe"],
+        cwd: activeFilePath,
+      }
+    );
 
     let stdout = "";
     let stderr = "";
 
-    cargoBuild.stdout.on("data", (data: Buffer) => {
+    cargoBuild.stdout?.on("data", (data: Buffer) => {
       stdout += data;
     });
 
-    cargoBuild.stderr.on("data", (data: Buffer) => {
+    cargoBuild.stderr?.on("data", (data: Buffer) => {
       logDebugConsole(data.toString());
       stderr += data;
     });

--- a/src/compiler/rustConfig.ts
+++ b/src/compiler/rustConfig.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as toml from "toml";
+import { LogToDebugConsole } from "./types";
+
+function findCargoConfig(startDir: string): string | null {
+  let dir = startDir;
+  while (dir !== path.parse(dir).root) {
+    const configPath = path.join(dir, ".cargo", "config.toml");
+    if (fs.existsSync(configPath)) {
+      return configPath;
+    }
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+function rustConfigWasiTarget(
+  logDebugConsole: LogToDebugConsole,
+  startDir: string
+): string {
+  let wasiTarget = "wasm32-wasip1";
+  try {
+    const configPath = findCargoConfig(startDir);
+    if (configPath === null) {
+      throw new Error("No .cargo/config.toml found");
+    }
+    const configContent = fs.readFileSync(configPath, "utf-8");
+    const config = toml.parse(configContent);
+    if (config?.build?.target) {
+      wasiTarget = config.build.target;
+    }
+  } catch (error) {
+    logDebugConsole(
+      `Failed to read or parse config.toml (fallback target: ${wasiTarget})`,
+      "stderr"
+    );
+  } finally {
+    return wasiTarget;
+  }
+}
+
+export { rustConfigWasiTarget };


### PR DESCRIPTION
now using treekill
Rust: now has  target fallback for missing `.cargo/config.toml`