### PR TITLE
update config usage for re-use tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,8 @@ fastedge-cli/
 # VSCode workspace
 .vscode/
 
-# FastEdge build artifacts
-.fastedge/bin/
+# FastEdge debug artifacts
+.fastedge-debug/
 
 # VSIX package
 fastedge-*.vsix

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Please be aware that if you are adding **sensitive** information to these files,
 .env.*
 
 # Build artifacts
-.fastedge/
+.fastedge-debug/
 ```
 
 For more information on how the extension locates and uses dotenv files, see [DOTENV.md](https://github.com/G-Core/FastEdge-vscode/blob/main/DOTENV.md).

--- a/context/BUNDLED_DEBUGGER.md
+++ b/context/BUNDLED_DEBUGGER.md
@@ -23,13 +23,13 @@ Extension contains bundled debugger (dist/debugger/)
     ↓
 User opens a file in an app folder and runs "FastEdge: Run File"
     ↓
-Extension resolves config root (nearest fastedge-config.test.json) and build root (nearest package.json / Cargo.toml)
+Extension resolves config root (nearest .fastedge-debug/ directory) and build root (nearest package.json / Cargo.toml)
     ↓
-Extension reads <configRoot>/.debug-port (if present) → health-checks
+Extension reads <configRoot>/.fastedge-debug/.debug-port (if present) → health-checks
     ↓
 If healthy: reuse existing server   If missing/stale: fork new server on next free port
     ↓
-Server writes port to <configRoot>/.debug-port
+Server writes port to <configRoot>/.fastedge-debug/.debug-port
     ↓
 Per-app webview panel opens ("FastEdge Debugger — <appName>")
 ```
@@ -50,7 +50,7 @@ Multiple apps open simultaneously each get their own server on separate ports (5
 - Real-time logs via WebSocket
 
 **3. Extension Integration**
-- `src/utils/resolveAppRoot.ts` - Two functions: `resolveConfigRoot()` (finds `fastedge-config.test.json`) and `resolveBuildRoot()` (finds `package.json` / `Cargo.toml`). `ensureConfigFile()` creates a minimal `{}` config when none exists (third-app case).
+- `src/utils/resolveAppRoot.ts` - Two functions: `resolveConfigRoot()` (finds `.fastedge-debug/` directory) and `resolveBuildRoot()` (finds `package.json` / `Cargo.toml`). `ensureDebugDir()` creates the `.fastedge-debug/` directory when none exists (third-app case).
 - `DebuggerServerManager.ts` - Manages server lifecycle **per app root** — one instance per app
 - `extension.ts` - Maintains `Map<appRoot, DebuggerServerManager>` and `Map<appRoot, DebuggerWebviewProvider>`
 - Uses `child_process.fork()` to spawn server
@@ -155,16 +155,16 @@ this.serverProcess = fork(bundledServerPath, [], {
 
 **4. One server per app root (March 2026)**
 - Before: Single global server on port 5179 shared by all apps
-- After: One server per app folder; port file at `<configRoot>/.debug-port` for discovery
-- Isolation boundary: nearest ancestor dir containing `fastedge-config.test.json` (`configRoot`)
-- If no config file exists, a minimal `{}` one is auto-created **co-located with the active file** on first run — making that directory its own configRoot
+- After: One server per app folder; port file at `<configRoot>/.fastedge-debug/.debug-port` for discovery
+- Isolation boundary: nearest ancestor dir containing `.fastedge-debug/` (`configRoot`)
+- If no `.fastedge-debug/` directory exists, one is auto-created **co-located with the active file** on first run — making that directory its own configRoot
 - Closing the debug panel stops that app's server and deletes its port file
 
 **8. Config root vs build root split (March 2026)**
 - Before: Single `resolveAppRoot()` used for both build CWD and per-app identity — `fastedge-config.test.json` could override the build root incorrectly
 - After: `resolveConfigRoot()` finds the per-app anchor; `resolveBuildRoot()` finds where build commands run
 - Example — workspace-1: `first-app/fastedge-config.test.json` → configRoot = `first-app/`; `package.json` at workspace root → buildRoot = `workspace-1/`
-- WASM output (`.fastedge/bin/debugger.wasm`) is written to `configRoot` so the server can find it via `WORKSPACE_PATH`
+- WASM output (`<configRoot>/.fastedge-debug/app.wasm`) is written to configRoot's `.fastedge-debug/` so the server can find it via `WORKSPACE_PATH`
 
 **6. Wait for WebSocket client before loading WASM (March 2026)**
 - Before: extension called `POST /api/load` immediately after creating the webview panel → `wasm_loaded` event fired before UI WebSocket connected → UI missed it, stayed blank
@@ -392,10 +392,10 @@ No configuration needed! But these settings are available:
 
 3. Check for the port file — it tells you which port this app's server is on:
    ```bash
-   cat <configRoot>/.debug-port   # e.g. cat first-app/.debug-port
+   cat <configRoot>/.fastedge-debug/.debug-port   # e.g. cat first-app/.fastedge-debug/.debug-port
    lsof -i :<port>
    ```
-   `configRoot` is the directory containing `fastedge-config.test.json` for the app you're debugging.
+   `configRoot` is the directory containing `.fastedge-debug/` for the app you're debugging.
 
 ### Extension won't install
 

--- a/context/CHANGELOG.md
+++ b/context/CHANGELOG.md
@@ -39,7 +39,7 @@ Added two right-click context menu commands in the VSCode file explorer as the s
 ## [2026-03-18] - DotenvPanel: show resolved app root as default path label
 
 ### Overview
-The dotenv path default display was showing `"workspace root (default)"` — a misleading label, since the actual default is the app root (resolved via `resolveConfigRoot`: nearest `fastedge-config.test.json`, or `package.json`/`Cargo.toml`). Now the panel requests the real path from the extension on mount and displays it when no custom path is set.
+The dotenv path default display was showing `"workspace root (default)"` — a misleading label, since the actual default is the app root (resolved via `resolveConfigRoot`: nearest `.fastedge-debug/` directory, or `package.json`/`Cargo.toml`). Now the panel requests the real path from the extension on mount and displays it when no custom path is set.
 
 ### 🎯 What Was Completed
 
@@ -129,7 +129,7 @@ Removed four legacy/redundant commands and renamed the workspace command to bett
 #### Dead code removed
 - `src/commands/launchJson.ts` — deleted
 - `src/commands/index.ts` — removed `launchJson` re-export
-- `src/extension.ts` — removed `startDebuggerServer`, `stopDebuggerServer`, `debugFastEdgeApp`, `getActiveAppRoot` functions and their imports (`createLaunchJson`, `resolveConfigRoot`, `resolveBuildRoot`, `ensureConfigFile`)
+- `src/extension.ts` — removed `startDebuggerServer`, `stopDebuggerServer`, `debugFastEdgeApp`, `getActiveAppRoot` functions and their imports (`createLaunchJson`, `resolveConfigRoot`, `resolveBuildRoot`, `ensureDebugDir`)
 - `src/types.ts` — removed `LaunchConfiguration` interface (unused)
 - `package.json` — removed dead `configurationAttributes` fields (kept only `entrypoint`); removed unused deps `@vscode/debugadapter`, `@vscode/debugprotocol`
 
@@ -142,10 +142,10 @@ Removed four legacy/redundant commands and renamed the workspace command to bett
 
 ---
 
-## [2026-03-12] - Config Root vs Build Root Split + .debug-port Sidecar
+## [2026-03-12] - Config Root vs Build Root Split + .fastedge-debug/ Directory
 
 ### Overview
-Refactored app root resolution to separate two previously conflated concerns: where the build runs (build root = `package.json` / `Cargo.toml`) and which directory anchors per-app isolation (config root = `fastedge-config.test.json`). Moved `.debug-port` from `.fastedge/.debug-port` to a direct sibling of `fastedge-config.test.json`. For apps with no config file, the file is now auto-created next to the active file rather than at the build root.
+Refactored app root resolution to separate two previously conflated concerns: where the build runs (build root = `package.json` / `Cargo.toml`) and which directory anchors per-app isolation (config root = `.fastedge-debug/` directory). Moved `.debug-port` from `.fastedge/.debug-port` to `{configRoot}/.fastedge-debug/.debug-port`. For apps with no `.fastedge-debug/` directory, one is auto-created next to the active file rather than at the build root.
 
 ### Background
 
@@ -155,31 +155,31 @@ The old `resolveAppRoot()` returned the first directory containing any of `faste
 
 #### 1. `resolveAppRoot.ts` — split into three exports
 
-- `resolveConfigRoot(startPath)` — walks up to find `fastedge-config.test.json`; returns `null` if not found
+- `resolveConfigRoot(startPath)` — walks up to find `.fastedge-debug/` directory; returns `null` if not found
 - `resolveBuildRoot(startPath)` — walks up to find `package.json` or `Cargo.toml`
-- `ensureConfigFile(dir)` — writes `{}` to `fastedge-config.test.json` if it doesn't exist (no-op otherwise)
+- `ensureDebugDir(dir)` — creates `.fastedge-debug/` directory if it doesn't exist (no-op otherwise)
 
 Old `resolveAppRoot()` export removed entirely.
 
 #### 2. Call site updates
 
-- `rustBuild.ts` / `jsBuild.ts` — build `cwd` and `package.json` reads now use `resolveBuildRoot()`; `.fastedge/bin/` WASM output uses `resolveConfigRoot() ?? buildRoot`
+- `rustBuild.ts` / `jsBuild.ts` — build `cwd` and `package.json` reads now use `resolveBuildRoot()`; `.fastedge-debug/` WASM output uses `resolveConfigRoot() ?? buildRoot`
 - `runDebugger.ts` / `extension.ts:getActiveAppRoot()` — port anchor uses `resolveConfigRoot()`; falls back to creating config at `path.dirname(activeFile)` (the active file's directory, not the build root)
 
-#### 3. `.debug-port` moved to sidecar
+#### 3. `.debug-port` moved into `.fastedge-debug/`
 
 - **Before**: `{configRoot}/.fastedge/.debug-port`
-- **After**: `{configRoot}/.debug-port` (direct sibling of `fastedge-config.test.json`)
+- **After**: `{configRoot}/.fastedge-debug/.debug-port` (inside the `.fastedge-debug/` directory)
 - `writePortFile()` in `fastedge-test/server/server.ts` no longer needs to `mkdirSync` for the port file
 - `PORT_FILE_DIR` constant removed from `DebuggerServerManager.ts`
 
 #### 4. Third-app fallback: config created at active file's directory
 
-When no `fastedge-config.test.json` is found, one is created co-located with the active file (`path.dirname(activeFilePath)`). This makes that directory its own configRoot, giving the app its own `.debug-port` without assuming anything about project structure.
+When no `.fastedge-debug/` directory is found, one is created co-located with the active file (`path.dirname(activeFilePath)`). This makes that directory its own configRoot, giving the app its own `.fastedge-debug/.debug-port` without assuming anything about project structure.
 
 #### 5. Tests added
 
-- `src/utils/resolveAppRoot.test.ts` — 17 vitest tests covering all workspace layouts (workspace-1, workspace-2 variants, Rust/Cargo.toml, null cases, `ensureConfigFile` idempotency)
+- `src/utils/resolveAppRoot.test.ts` — 17 vitest tests covering all workspace layouts (workspace-1, workspace-2 variants, Rust/Cargo.toml, null cases, `ensureDebugDir` idempotency)
 - `vitest ^2.1.9` added to devDependencies; `pnpm test` script added
 
 **Files Modified:**
@@ -199,7 +199,7 @@ When no `fastedge-config.test.json` is found, one is created co-located with the
 ## [2026-03-11] - Config File Rename + Native Load/Save Dialogs
 
 ### Overview
-Updated to use the renamed `fastedge-config.test.json` (previously `test-config.json`) as the app root marker. Implemented native VSCode load and save file dialogs for the debugger's config buttons — previously all dialog strategies failed silently in the sandboxed iframe context.
+Updated to use the renamed `fastedge-config.test.json` (previously `test-config.json`) as the app root marker (later replaced by `.fastedge-debug/` directory as the marker). Implemented native VSCode load and save file dialogs for the debugger's config buttons — previously all dialog strategies failed silently in the sandboxed iframe context.
 
 ### Background
 
@@ -220,9 +220,9 @@ Both load and save detect `window !== window.top` and delegate to the extension 
 - Dialog opens at the app's root directory
 
 #### 3. Save Config — Native Save Dialog
-- Extension handler: `openSavePicker` → `vscode.window.showSaveDialog({ defaultUri: appRoot/fastedge-config.test.json })` → posts `savePickerResult` back
+- Extension handler: `openSavePicker` → `vscode.window.showSaveDialog({ defaultUri: appRoot/.fastedge-debug/fastedge-config.test.json })` → posts `savePickerResult` back
 - Frontend calls `POST /api/config/save-as` with the returned path; server writes the file
-- Always suggests `fastedge-config.test.json` so the saved file doubles as the app root marker
+- Defaults to `.fastedge-debug/fastedge-config.test.json` inside the app's debug directory
 
 #### 4. Webview HTML Bridge
 - Forwards `openFilePicker`, `openSavePicker` from iframe → extension host
@@ -248,24 +248,24 @@ The original architecture created one global `DebuggerServerManager` from `works
 - **Two VSCode windows** each debugging a different app: config changes in one bled into the other via the shared server state.
 - **Multi-root workspace** (`/my-cdn-app` + `/my-http-app` in one window): the build always ran from the workspace root, so `npx fastedge-build` and `cargo build` couldn't find the correct `node_modules/.bin/fastedge-build` or `Cargo.toml` for child apps. HTTP WASM builds failed entirely.
 
-The isolation boundary is the **app folder** — the nearest ancestor directory containing `fastedge-config.test.json`, `package.json`, or `Cargo.toml`.
+The isolation boundary is the **app folder** — the nearest ancestor directory containing `.fastedge-debug/`, `package.json`, or `Cargo.toml`.
 
 ### 🎯 What Was Completed
 
 #### 1. `resolveAppRoot()` utility (`src/utils/resolveAppRoot.ts`) — NEW FILE
-- Walks up from a file path, checking each directory for (in priority order): `fastedge-config.test.json` → `package.json` → `Cargo.toml`
+- Walks up from a file path, checking each directory for (in priority order): `.fastedge-debug/` → `package.json` → `Cargo.toml`
 - All three markers checked at each level before moving up (avoids false positives from nested manifests)
 - Returns `null` if no marker found (surfaced as user-visible error)
 - Used by build, server, and panel code as the single source of app identity
 
 #### 2. Build root fix (`src/compiler/jsBuild.ts`, `rustBuild.ts`, `compiler/index.ts`)
 - `compileJavascriptBinary`: replaces `workspaceFolders[0]` with `resolveAppRoot(activeFilePath)` for CWD, bin dir, and `package.json` entry point lookup
-- `compileRustAndFindBinary`: `cwd` for `cargo build` and `.fastedge/bin/` copy destination now use app root
+- `compileRustAndFindBinary`: `cwd` for `cargo build` and `.fastedge-debug/` copy destination now use app root
 - `compiler/index.ts`: workspace mode no longer anchors to `workspaceFolders[0]`; always derives root from active file
 
 #### 3. Per-app `DebuggerServerManager` (`src/debugger/DebuggerServerManager.ts`)
 - Constructor now takes `appRoot` instead of `workspacePath`
-- `start()` reads `<appRoot>/.fastedge/.debug-port`, health-checks the port, reuses if healthy or spawns fresh if stale/missing
+- `start()` reads `<appRoot>/.fastedge-debug/.debug-port`, health-checks the port, reuses if healthy or spawns fresh if stale/missing
 - `stop()` sends SIGTERM and deletes the port file
 - Spawns server with `WORKSPACE_PATH: appRoot` (used by server for dotenv and port file)
 - On unexpected process exit: port file is deleted
@@ -299,7 +299,7 @@ The isolation boundary is the **app folder** — the nearest ancestor directory 
 - Stale port file: detected and cleaned up on next `start()`
 
 ### 📝 Key Design Decisions
-- **App root = nearest manifest ancestor**: `fastedge-config.test.json` wins over `package.json`/`Cargo.toml` because it is always at the FastEdge app root by convention. Language manifests may exist in parent directories (monorepo root `package.json`, cargo workspace).
+- **App root = nearest manifest ancestor**: `.fastedge-debug/` wins over `package.json`/`Cargo.toml` because it is always at the FastEdge app root by convention. Language manifests may exist in parent directories (monorepo root `package.json`, cargo workspace).
 - **Port file owned by the server, read by the extension**: server writes it after `httpServer.listen()`, deletes on shutdown. Extension reads it at start time only.
 - **Agents never spawn servers**: if an agent finds no port file for the app it's working in, it should prompt the user to open the debug panel first. (T010/T011 in fastedge-plugin — not yet implemented.)
 

--- a/context/CONTEXT_INDEX.md
+++ b/context/CONTEXT_INDEX.md
@@ -227,7 +227,7 @@ See `SEARCH_GUIDE.md` for more patterns.
    - Rust: Uses `cargo build` with wasm32-wasip1 target
    - JavaScript: Uses `fastedge-build` tool
    - AssemblyScript: Uses `asc --target release` (CDN/proxy-wasm apps)
-   - All output to `<configRoot>/.fastedge/bin/debugger.wasm`
+   - All output to `<configRoot>/.fastedge-debug/app.wasm`
 
 4. **Commands** (`src/commands/`)
    - Generate mcp.json
@@ -236,14 +236,14 @@ See `SEARCH_GUIDE.md` for more patterns.
 
 5. **Configuration** (`src/dotenv/`, `src/utils/resolveAppRoot.ts`)
    - Dotenv file auto-discovery from `configRoot`
-   - `fastedge-config.test.json` as app root marker + runtime config store
-   - `resolveConfigRoot()` / `resolveBuildRoot()` for per-app isolation
+   - `.fastedge-debug/` directory as app root marker; `fastedge-config.test.json` as runtime config store
+   - `resolveConfigRoot()` (finds `.fastedge-debug/`) / `resolveBuildRoot()` for per-app isolation
 
 ### Key Terms
 
 - **FastEdge-run**: Bundled CLI that runs WASM binaries locally
-- **fastedge-config.test.json**: Per-app config file; also the `configRoot` anchor for server isolation
-- **configRoot**: Directory containing `fastedge-config.test.json` — anchors per-app server + port file
+- **fastedge-config.test.json**: Per-app config file for runtime settings (env vars, secrets, headers)
+- **configRoot**: Directory containing `.fastedge-debug/` — anchors per-app server + port file
 - **buildRoot**: Directory containing `package.json` or `Cargo.toml` — anchors build CWD
 - **dotenv hierarchy**: .env → .env.variables → .env.secrets (see DOTENV.md in root)
 - **WASM**: WebAssembly - compiled output of Rust/JS/AS code

--- a/context/PROJECT_OVERVIEW.md
+++ b/context/PROJECT_OVERVIEW.md
@@ -67,7 +67,7 @@ The extension provides several VS Code commands:
 
 Runtime config is managed in two places:
 
-1. **fastedge-config.test.json** — env vars, secrets, headers, port, memory limits. Loaded/saved via the debugger UI using native VSCode file dialogs. Also serves as the per-app root marker for server isolation.
+1. **fastedge-config.test.json** — env vars, secrets, headers, port, memory limits. Loaded/saved via the debugger UI using native VSCode file dialogs. The per-app root marker for server isolation is the `.fastedge-debug/` directory.
 
 2. **Dotenv files** (`.env`, `.env.variables`, `.env.secrets`, `.env.req_headers`, `.env.rsp_headers`) — auto-discovered from the app's config root directory.
 
@@ -85,7 +85,7 @@ Runtime config is managed in two places:
 - Current File mode: Uses active editor file as entrypoint
 - Workspace mode: Uses `package.json` "main" field as entrypoint
 - Runs `fastedge-build <input> <output>`
-- Default output: `.fastedge/bin/debugger.wasm`
+- Default output: `.fastedge-debug/app.wasm`
 
 ### 5. Runtime Execution
 
@@ -192,7 +192,7 @@ FastEdge-vscode/
 2. App roots resolved: `resolveConfigRoot()` + `resolveBuildRoot()` from active file
 3. Compilation:
    - Rust: `cargo build --target wasm32-wasip1` from `buildRoot`
-   - JS: `fastedge-build` from `buildRoot`, output to `{configRoot}/.fastedge/bin/debugger.wasm`
+   - JS: `fastedge-build` from `buildRoot`, output to `<configRoot>/.fastedge-debug/app.wasm`
    - AS: `asc --target release` with proxy-wasm support
 4. Per-app `DebuggerServerManager` started (or reused) for `configRoot`
 5. WASM auto-loaded into debugger via REST API

--- a/context/architecture/CONFIGURATION_SYSTEM.md
+++ b/context/architecture/CONFIGURATION_SYSTEM.md
@@ -23,7 +23,7 @@ The extension itself reads only one launch config field: **`"entrypoint"`** (`"f
 
 **Note**: The per-app isolation marker is the `.fastedge-debug/` directory, not this file. `resolveConfigRoot()` walks up from the active file to find `.fastedge-debug/`; the directory containing it becomes the `configRoot`.
 
-**Location**: Any directory in the project, co-located with the app entry file. Auto-created (as `{}`) at the active file's directory when no config file is found on first debug.
+**Location**: Any directory in the project, typically inside `.fastedge-debug/`. The config file is **not** auto-created; only the `.fastedge-debug/` directory is created automatically on first debug. Users create the config via the debugger UI's save dialog.
 
 **Loaded/saved via**: Native VSCode file dialogs (`vscode.window.showOpenDialog` / `vscode.window.showSaveDialog`), not browser file APIs. The extension bridges iframe postMessages to the extension host to work around the sandboxed webview context.
 

--- a/context/architecture/CONFIGURATION_SYSTEM.md
+++ b/context/architecture/CONFIGURATION_SYSTEM.md
@@ -19,15 +19,15 @@ The extension itself reads only one launch config field: **`"entrypoint"`** (`"f
 
 ## fastedge-config.test.json
 
-**Role**: Primary config file for a FastEdge app. Serves a dual purpose:
-1. **App root marker** — `resolveConfigRoot()` walks up from the active file to find it; the directory containing it becomes the `configRoot` for per-app isolation
-2. **Runtime config store** — env vars, secrets, headers, port, memory limits
+**Role**: Primary config file for a FastEdge app. Serves as the **runtime config store** — env vars, secrets, headers, port, memory limits.
+
+**Note**: The per-app isolation marker is the `.fastedge-debug/` directory, not this file. `resolveConfigRoot()` walks up from the active file to find `.fastedge-debug/`; the directory containing it becomes the `configRoot`.
 
 **Location**: Any directory in the project, co-located with the app entry file. Auto-created (as `{}`) at the active file's directory when no config file is found on first debug.
 
 **Loaded/saved via**: Native VSCode file dialogs (`vscode.window.showOpenDialog` / `vscode.window.showSaveDialog`), not browser file APIs. The extension bridges iframe postMessages to the extension host to work around the sandboxed webview context.
 
-**If not found**: `ensureConfigFile(dir)` creates `{}` at `path.dirname(activeFilePath)`.
+**If not found**: `ensureDebugDir(dir)` creates `.fastedge-debug/` at `path.dirname(activeFilePath)`.
 
 ---
 
@@ -37,12 +37,12 @@ Two separate utilities in `src/utils/resolveAppRoot.ts`:
 
 | Function | Walks up for | Used by |
 |----------|-------------|---------|
-| `resolveConfigRoot(startPath)` | `fastedge-config.test.json` | Port anchor, panel isolation, WASM output dir |
+| `resolveConfigRoot(startPath)` | `.fastedge-debug/` directory | Port anchor, panel isolation, WASM output dir |
 | `resolveBuildRoot(startPath)` | `package.json` or `Cargo.toml` | Build CWD, entrypoint resolution |
 
 These are deliberately separate — in a monorepo the `package.json` may be several levels above the app's own `fastedge-config.test.json`.
 
-**`.debug-port` sidecar**: Written by the server at `{configRoot}/.debug-port` (direct sibling of `fastedge-config.test.json`) after `httpServer.listen()`. The extension reads it at startup to find the per-app server port.
+**`.debug-port` file**: Written by the server at `{configRoot}/.fastedge-debug/.debug-port` (inside the `.fastedge-debug/` directory) after `httpServer.listen()`. The extension reads it at startup to find the per-app server port.
 
 ---
 

--- a/context/architecture/DEBUGGER_ARCHITECTURE.md
+++ b/context/architecture/DEBUGGER_ARCHITECTURE.md
@@ -406,7 +406,7 @@ curl http://localhost:5179/health
 1. **Auto-restart on crash** - Automatically restart server if it crashes
 2. **Multiple instances** - Support multiple debugger servers on different ports
 3. **Build integration** - Automatically compile and load WASM when file changes
-4. **Agent REST API access** - Agents reading `.debug-port` to hit the REST API directly (tracked in fastedge-plugin)
+4. **Agent REST API access** - Agents reading `.fastedge-debug/.debug-port` to hit the REST API directly (tracked in fastedge-plugin)
 5. **GitHub Actions automation** - Download pre-built debugger bundles from releases
 
 ---

--- a/context/architecture/EXTENSION_LIFECYCLE.md
+++ b/context/architecture/EXTENSION_LIFECYCLE.md
@@ -143,7 +143,7 @@ vscode.workspace.getConfiguration('fastedge').update(
 1. **User triggers debug command** (F5, `run-file`, or `run-workspace`)
 2. **App root resolved** from active file via `resolveConfigRoot()` / `resolveBuildRoot()`
 3. **Per-app manager lookup**: `Map<appRoot, DebuggerServerManager>` — creates lazily if not present
-4. **Build**: Compiler runs (Rust/JS/AS), output to `{configRoot}/.fastedge/bin/debugger.wasm`
+4. **Build**: Compiler runs (Rust/JS/AS), output to `<configRoot>/.fastedge-debug/app.wasm`
 5. **Server start**: `debuggerServerManager.start()` forks bundled `dist/debugger/server.js` using `process.execPath`
 6. **Port resolved**: `resolvePort()` scans 5179–5188, reuses own server or picks free port
 7. **Webview opened**: Panel titled `"FastEdge Debugger — {appName}"` loads debugger UI in iframe
@@ -357,7 +357,7 @@ Per-app `DebuggerServerManager` / `DebuggerWebviewProvider` instances are create
 - Each app folder gets its own isolated server + webview panel
 - App root resolved from the active file — not from `workspaceFolders[0]`
 - Build CWD uses `resolveBuildRoot()` to find the nearest `package.json` / `Cargo.toml`
-- Config isolation uses `resolveConfigRoot()` to find the nearest `fastedge-config.test.json`
+- Config isolation uses `resolveConfigRoot()` to find the nearest `.fastedge-debug/` directory
 - Two apps can debug simultaneously on different ports (5179, 5180, etc.)
 
 ---

--- a/context/archived/README.md
+++ b/context/archived/README.md
@@ -10,7 +10,7 @@ The extension originally implemented VS Code's **Debug Adapter Protocol (DAP)** 
 
 - A bundled Node server (`dist/debugger/server.js`) started via `fork()`
 - A webview panel embedding the debugger UI
-- Per-app root isolation with `fastedge-config.test.json` as the anchor
+- Per-app root isolation with `.fastedge-debug/` directory as the anchor
 - Runtime config managed entirely in the debugger UI (not launch.json)
 
 ## When to read these files

--- a/context/features/COMMANDS.md
+++ b/context/features/COMMANDS.md
@@ -46,7 +46,7 @@ Builds the **active editor file** as the WASM entry point, starts a per-app debu
 
 ### Full Workflow
 
-1. **Resolve app identity** — finds nearest `fastedge-config.test.json` as `configRoot` (creates one at the active file's directory if none found)
+1. **Resolve app identity** — finds nearest `.fastedge-debug/` directory as `configRoot` (creates one at the active file's directory if none found)
 2. **Build WASM** — compiles using active file as entry point; shows output in a "FastEdge Build" pseudoterminal (auto-closes after 3s on success, stays open on failure)
 3. **Start debugger server** — lazy-starts a per-`configRoot` server on port 5179–5188; reuses existing server if healthy
 4. **Open debugger webview** — polls `/api/client-count` until UI WebSocket connects (max 5s), then calls `POST /api/load` with the WASM path

--- a/context/features/COMPILER_SYSTEM.md
+++ b/context/features/COMPILER_SYSTEM.md
@@ -28,7 +28,7 @@ All three compilers use two root concepts resolved by `src/utils/resolveAppRoot.
 
 **`resolveBuildRoot(activeFilePath)`** — walks up from the active file to find the nearest directory containing `package.json` or `Cargo.toml`. This is where build commands run (CWD for spawned processes).
 
-**`resolveConfigRoot(activeFilePath)`** — walks up to find the nearest directory containing `fastedge-config.test.json`. This is the per-app anchor: the debugger server's `WORKSPACE_PATH`, and where `.fastedge/bin/debugger.wasm` is written. Falls back to `buildRoot` if not found.
+**`resolveConfigRoot(activeFilePath)`** — walks up to find the nearest directory containing `.fastedge-debug/`. This is the per-app anchor: the debugger server's `WORKSPACE_PATH`, and where `.fastedge-debug/app.wasm` is written. Falls back to `buildRoot` if not found.
 
 The separation of build root vs config root is what allows multiple apps in the same workspace to have isolated debug ports without interfering with each other.
 
@@ -86,7 +86,7 @@ rustup target add wasm32-wasip1
 3. Read WASI target from `.cargo/config.toml` via `rustConfigWasiTarget()` — falls back to `wasm32-wasip1`
 4. Spawn `cargo build --message-format=json --target=<wasiTarget>` at `buildRoot`
 5. Parse JSON output line-by-line; find the `compiler-artifact` entry with a `.wasm` filename
-6. Copy WASM to `<configRoot>/.fastedge/bin/debugger.wasm`
+6. Copy WASM to `<configRoot>/.fastedge-debug/app.wasm`
 
 **Note**: `cargo build` stderr (human-readable progress) is piped to the build console. The `--message-format=json` stdout is consumed internally for artifact path extraction.
 
@@ -128,11 +128,11 @@ npm install --save-dev @gcoredev/fastedge-sdk-js
 **Steps**:
 1. Resolve `buildRoot` (directory containing `package.json`)
 2. Resolve `configRoot` (falls back to `buildRoot`)
-3. Create `<configRoot>/.fastedge/bin/` directory
+3. Create `<configRoot>/.fastedge-debug/` directory
 4. Determine entry point:
    - **File mode**: active file path
    - **Workspace mode**: `package.json` `main` field resolved relative to `buildRoot`
-5. Spawn `npx fastedge-build <entryPoint> <configRoot>/.fastedge/bin/debugger.wasm` at `buildRoot`
+5. Spawn `npx fastedge-build <entryPoint> <configRoot>/.fastedge-debug/app.wasm` at `buildRoot`
 
 ### Entrypoint Modes
 
@@ -191,7 +191,7 @@ my-app/
 }
 ```
 
-**Note**: The `outFile` in `asconfig.json` is overridden by the extension — output always goes to `.fastedge/bin/debugger.wasm`.
+**Note**: The `outFile` in `asconfig.json` is overridden by the extension — output always goes to `.fastedge-debug/app.wasm`.
 
 ### Build Process
 
@@ -201,8 +201,8 @@ my-app/
 1. Resolve `buildRoot` (directory containing `package.json`)
 2. Verify `asconfig.json` exists at `buildRoot` — throws if missing
 3. Resolve `configRoot` (falls back to `buildRoot`)
-4. Create `<configRoot>/.fastedge/bin/` directory
-5. Spawn: `npx asc assembly/index.ts --target release --outFile <configRoot>/.fastedge/bin/debugger.wasm` at `buildRoot`
+4. Create `<configRoot>/.fastedge-debug/` directory
+5. Spawn: `npx asc assembly/index.ts --target release --outFile <configRoot>/.fastedge-debug/app.wasm` at `buildRoot`
 
 The `--target release` flag picks up optimization settings from `asconfig.json` (shrink level, no-assert, etc.). `--outFile` overrides only the output path to the standard debugger location.
 
@@ -240,12 +240,12 @@ Returns `BinaryInfo: { path: string; lang: ExtLanguage }` where `ExtLanguage = "
 
 All three compilers write to the same path:
 ```
-<configRoot>/.fastedge/bin/debugger.wasm
+<configRoot>/.fastedge-debug/app.wasm
 ```
 
-`configRoot` is the directory containing `fastedge-config.test.json` (or `buildRoot` if none exists). This path is what the debugger server receives via `POST /api/load` and serves via `/api/workspace-wasm`.
+`configRoot` is the directory containing `.fastedge-debug/` (or `buildRoot` if none exists). This path is what the debugger server receives via `POST /api/load` and serves via `/api/workspace-wasm`.
 
-`.fastedge/bin/` can be safely gitignored.
+`.fastedge-debug/` can be safely gitignored.
 
 ---
 
@@ -267,7 +267,7 @@ AssemblyScript always builds in release mode because the AS `--target release` s
 2. **AS ≠ JS** — AssemblyScript detected by `asconfig.json` at `buildRoot`, not language ID (VSCode reports AS as `typescript`)
 3. **Two root concepts** — `buildRoot` (where build runs) and `configRoot` (where output goes), allowing multi-app workspaces
 4. **Fixed AS entry point** — always `assembly/index.ts`; no file vs workspace mode
-5. **Uniform output** — all three compilers write to `<configRoot>/.fastedge/bin/debugger.wasm`
+5. **Uniform output** — all three compilers write to `<configRoot>/.fastedge-debug/app.wasm`
 
 ---
 

--- a/context/features/CROSS_PLATFORM.md
+++ b/context/features/CROSS_PLATFORM.md
@@ -50,13 +50,13 @@ If you add new shell-invoked commands to mcp.json generation, follow the same br
 ```typescript
 // ✅ correct — extension-side file ops
 import path from "path";
-path.join(configRoot, ".fastedge", "bin", "debugger.wasm");
+path.join(configRoot, ".fastedge-debug", "app.wasm");
 
 // ✅ correct — VS Code API file ops
 vscode.Uri.joinPath(workspaceFolder.uri, ".vscode", "mcp.json");
 
 // ❌ wrong — breaks on Windows
-configRoot + "/" + ".fastedge/bin/debugger.wasm";
+configRoot + "/" + ".fastedge-debug/app.wasm";
 ```
 
 ### Temp files — always use `os.tmpdir()`

--- a/context/features/DOTENV_SYSTEM.md
+++ b/context/features/DOTENV_SYSTEM.md
@@ -116,7 +116,7 @@ Runtime config in `fastedge-config.test.json` (edited in the debugger UI) takes 
 
 **Always on** — no configuration required:
 
-1. **Start location**: `configRoot` (directory containing `fastedge-config.test.json`)
+1. **Start location**: `configRoot` (directory containing `.fastedge-debug/`)
 
 2. **Walk up directory tree**:
 ```typescript
@@ -478,13 +478,14 @@ my-project/
 ├── config/
 │   ├── .env.variables
 │   └── .env.secrets
-├── fastedge-config.test.json
+├── .fastedge-debug/
+│   └── fastedge-config.test.json
 └── src/
     └── index.js
 ```
 
 **Discovery**:
-- Server starts from `configRoot` (directory with `fastedge-config.test.json`)
+- Server starts from `configRoot` (directory containing `.fastedge-debug/`)
 - Walks up, finds `config/` is not at or above `configRoot` — so place dotenv files at `configRoot` level or above for auto-discovery
 
 **Note**: Per-directory dotenv path override (old `"dotenv": "./config"` launch.json option) no longer exists. Place dotenv files where auto-discovery will find them.

--- a/src/commands/runDebugger.ts
+++ b/src/commands/runDebugger.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { readFile } from "fs/promises";
 import { DebuggerServerManager, DebuggerWebviewProvider } from "../debugger";
 import { compileActiveEditorsBinary } from "../compiler";
-import { resolveConfigRoot, resolveBuildRoot, ensureConfigFile } from "../utils/resolveAppRoot";
+import { resolveConfigRoot, resolveBuildRoot, ensureDebugDir } from "../utils/resolveAppRoot";
 import { DebugContext } from "../types";
 
 type AppDebuggerFactory = (appRoot: string) => {
@@ -78,14 +78,14 @@ async function buildAndDebug(debugContext: DebugContext): Promise<void> {
     return;
   }
 
-  // Resolve per-app identity anchor. If no fastedge-config.test.json exists yet,
-  // create a minimal one co-located with the active file so that the entrypoint
-  // directory becomes its own configRoot. This gives each app isolation without
-  // requiring the user to have pre-created a config file.
+  // Resolve per-app identity anchor. If no .fastedge-debug/ dir exists yet,
+  // create one co-located with the active file so that the entrypoint directory
+  // becomes its own configRoot. This gives each app isolation without requiring
+  // the user to have pre-created a debug directory.
   let portAnchor = resolveConfigRoot(activeFilePath);
   if (!portAnchor) {
     const activeDir = path.dirname(activeFilePath);
-    ensureConfigFile(activeDir);
+    ensureDebugDir(activeDir);
     portAnchor = activeDir;
   }
 
@@ -179,7 +179,7 @@ async function loadWasmInDebugger(uri?: vscode.Uri): Promise<void> {
   const wasmDir = path.dirname(wasmPath);
   const configRoot = resolveConfigRoot(wasmPath);
   if (!configRoot) {
-    ensureConfigFile(wasmDir);
+    ensureDebugDir(wasmDir);
   }
   const appRoot = configRoot ?? wasmDir;
 

--- a/src/commands/runDebugger.ts
+++ b/src/commands/runDebugger.ts
@@ -217,7 +217,8 @@ async function loadConfigInDebugger(uri?: vscode.Uri): Promise<void> {
   }
 
   const configPath = uri.fsPath;
-  const appRoot = path.dirname(configPath);
+  const configDir = path.dirname(configPath);
+  const appRoot = resolveConfigRoot(configPath) ?? configDir;
 
   const { provider } = debuggerFactory(appRoot);
 

--- a/src/compiler/asBuild.ts
+++ b/src/compiler/asBuild.ts
@@ -5,14 +5,14 @@ import path from "path";
 import { LogToDebugConsole } from "../types";
 import { resolveConfigRoot, resolveBuildRoot } from "../utils/resolveAppRoot";
 
-const BINARY_NAME = "debugger.wasm";
+const BINARY_NAME = "app.wasm";
 const AS_ENTRY_POINT = path.join("assembly", "index.ts");
 
-const makeBinDirectory = (appRoot: string) =>
+const makeDebugDirectory = (appRoot: string) =>
   new Promise<string>((resolve, reject) => {
-    const fastedgeBinDir = path.join(appRoot, ".fastedge", "bin");
-    fs.mkdir(fastedgeBinDir, { recursive: true }, (err) =>
-      err ? reject(err) : resolve(fastedgeBinDir)
+    const debugDir = path.join(appRoot, ".fastedge-debug");
+    fs.mkdir(debugDir, { recursive: true }, (err) =>
+      err ? reject(err) : resolve(debugDir)
     );
   });
 
@@ -37,10 +37,10 @@ export function compileAssemblyScriptBinary(
       }
 
       // WASM output goes to configRoot (= WORKSPACE_PATH) so the debugger server
-      // can serve it. Falls back to buildRoot when no fastedge-config.test.json
+      // can serve it. Falls back to buildRoot when no .fastedge-debug/ dir
       // exists (caller should have created it, but guard defensively).
       const configRoot = resolveConfigRoot(activeFilePath) ?? buildRoot;
-      const binPath = await makeBinDirectory(configRoot);
+      const binPath = await makeDebugDirectory(configRoot);
       const outFile = path.join(binPath, BINARY_NAME);
 
       // Use --target release to pick up optimisation settings from asconfig.json,

--- a/src/compiler/jsBuild.ts
+++ b/src/compiler/jsBuild.ts
@@ -5,13 +5,13 @@ import path from "path";
 import { DebugContext, LogToDebugConsole } from "../types";
 import { resolveConfigRoot, resolveBuildRoot } from "../utils/resolveAppRoot";
 
-const BINARY_NAME = "debugger.wasm";
+const BINARY_NAME = "app.wasm";
 
-const makeBinDirectory = (appRoot: string) =>
+const makeDebugDirectory = (appRoot: string) =>
   new Promise<string>((resolve, reject) => {
-    const fastedgeBinDir = path.join(appRoot, ".fastedge", "bin");
-    fs.mkdir(fastedgeBinDir, { recursive: true }, (err) =>
-      err ? reject(err) : resolve(fastedgeBinDir)
+    const debugDir = path.join(appRoot, ".fastedge-debug");
+    fs.mkdir(debugDir, { recursive: true }, (err) =>
+      err ? reject(err) : resolve(debugDir)
     );
   });
 
@@ -51,10 +51,10 @@ export function compileJavascriptBinary(
       }
 
       // WASM output goes to configRoot (= WORKSPACE_PATH) so the debugger server
-      // can serve it. Falls back to buildRoot when no fastedge-config.test.json
+      // can serve it. Falls back to buildRoot when no .fastedge-debug/ dir
       // exists (caller should have created it, but guard defensively).
       const configRoot = resolveConfigRoot(activeFilePath) ?? buildRoot;
-      const binPath = await makeBinDirectory(configRoot);
+      const binPath = await makeDebugDirectory(configRoot);
 
       const jsEntryPoint =
         debugContext === "file"

--- a/src/compiler/rustBuild.ts
+++ b/src/compiler/rustBuild.ts
@@ -26,8 +26,8 @@ export function compileRustAndFindBinary(
 
     // WASM output goes to the config root (= WORKSPACE_PATH) so the debugger
     // server can serve it via /api/workspace-wasm. Falls back to build root
-    // when no fastedge-config.test.json exists (should have been created by
-    // the caller, but guard defensively).
+    // when no .fastedge-debug/ dir exists (should have been created by the
+    // caller, but guard defensively).
     const configRoot = resolveConfigRoot(activeFilePath) ?? buildRoot;
 
     const target = rustConfigWasiTarget(logDebugConsole, activeFilePath);
@@ -90,13 +90,13 @@ export function compileRustAndFindBinary(
           if (/.*\.wasm$/.test(message.filenames[0])) {
             const cargoWasmPath = message.filenames[0];
 
-            // Copy to <configRoot>/.fastedge/bin/debugger.wasm for auto-load support.
+            // Copy to <configRoot>/.fastedge-debug/app.wasm for auto-load support.
             // configRoot = WORKSPACE_PATH so the server can find it via /api/workspace-wasm.
-            const fastedgeBinDir = path.join(configRoot, ".fastedge", "bin");
-            const standardWasmPath = path.join(fastedgeBinDir, "debugger.wasm");
+            const debugDir = path.join(configRoot, ".fastedge-debug");
+            const standardWasmPath = path.join(debugDir, "app.wasm");
 
             // Create directory if it doesn't exist
-            fs.mkdirSync(fastedgeBinDir, { recursive: true });
+            fs.mkdirSync(debugDir, { recursive: true });
 
             // Copy the WASM file
             try {

--- a/src/debugger/DebuggerServerManager.ts
+++ b/src/debugger/DebuggerServerManager.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as fs from "fs";
 
-const PORT_FILE_NAME = ".debug-port";
+const DEBUG_DIR = ".fastedge-debug";
 
 /**
  * Manages the lifecycle of the fastedge-debugger server for a specific app root.
@@ -20,7 +20,7 @@ export class DebuggerServerManager {
   ) {}
 
   private get portFilePath(): string {
-    return path.join(this.appRoot, PORT_FILE_NAME);
+    return path.join(this.appRoot, DEBUG_DIR, ".debug-port");
   }
 
   private readPortFile(): number | null {

--- a/src/debugger/DebuggerWebviewProvider.ts
+++ b/src/debugger/DebuggerWebviewProvider.ts
@@ -63,8 +63,9 @@ export class DebuggerWebviewProvider {
 
           if (message.command === "openFilePicker") {
             const appRoot = this.serverManager.getAppRoot();
+            const debugDir = path.join(appRoot, ".fastedge-debug");
             const uris = await vscode.window.showOpenDialog({
-              defaultUri: vscode.Uri.file(appRoot),
+              defaultUri: vscode.Uri.file(debugDir),
               canSelectMany: false,
               filters: { "JSON Files": ["json"] },
               title: "Load FastEdge Config",
@@ -103,9 +104,10 @@ export class DebuggerWebviewProvider {
 
           if (message.command === "openSavePicker") {
             const appRoot = this.serverManager.getAppRoot();
+            const debugDir = path.join(appRoot, ".fastedge-debug");
             const suggestedName = message.suggestedName ?? "fastedge-config.test.json";
             const uri = await vscode.window.showSaveDialog({
-              defaultUri: vscode.Uri.file(path.join(appRoot, suggestedName)),
+              defaultUri: vscode.Uri.file(path.join(debugDir, suggestedName)),
               filters: { "JSON Files": ["json"] },
               title: "Save FastEdge Config",
             });

--- a/src/utils/resolveAppRoot.test.ts
+++ b/src/utils/resolveAppRoot.test.ts
@@ -219,6 +219,50 @@ describe("ensureDebugDir", () => {
 });
 
 // ---------------------------------------------------------------------------
+// .fastedge-debug exists as a file (not a directory)
+// ---------------------------------------------------------------------------
+
+describe("resolveConfigRoot — .fastedge-debug is a file", () => {
+  it("skips a file named .fastedge-debug and returns null when no directory marker exists", () => {
+    touch(path.join(tmp, ".fastedge-debug")); // file, not directory
+    touch(path.join(tmp, "index.js"));
+
+    const result = resolveConfigRoot(path.join(tmp, "index.js"));
+    expect(result).toBeNull();
+  });
+
+  it("skips a file named .fastedge-debug and finds the real directory marker above", () => {
+    const child = path.join(tmp, "app");
+    touch(path.join(child, ".fastedge-debug")); // file in child
+    touch(path.join(child, "index.js"));
+    mkDebugDir(tmp); // real directory marker one level up
+
+    const result = resolveConfigRoot(path.join(child, "index.js"));
+    expect(result).toBe(tmp);
+  });
+});
+
+describe("ensureDebugDir — .fastedge-debug is a file", () => {
+  it("throws a clear error when .fastedge-debug already exists as a file", () => {
+    touch(path.join(tmp, ".fastedge-debug")); // file, not directory
+
+    expect(() => ensureDebugDir(tmp)).toThrowError(
+      /already exists as a file/,
+    );
+  });
+
+  it("does not remove the blocking file", () => {
+    touch(path.join(tmp, ".fastedge-debug"));
+
+    try { ensureDebugDir(tmp); } catch { /* expected */ }
+
+    // The file should still be there — ensureDebugDir must not delete it
+    expect(fs.existsSync(path.join(tmp, ".fastedge-debug"))).toBe(true);
+    expect(fs.statSync(path.join(tmp, ".fastedge-debug")).isFile()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Config root vs build root split — workspace-1 scenario end-to-end
 // ---------------------------------------------------------------------------
 

--- a/src/utils/resolveAppRoot.test.ts
+++ b/src/utils/resolveAppRoot.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { resolveConfigRoot, resolveBuildRoot, ensureConfigFile } from "./resolveAppRoot";
+import { resolveConfigRoot, resolveBuildRoot, ensureDebugDir } from "./resolveAppRoot";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -17,36 +17,40 @@ function touch(filePath: string): void {
   fs.writeFileSync(filePath, "", "utf8");
 }
 
+function mkDebugDir(dir: string): void {
+  fs.mkdirSync(path.join(dir, ".fastedge-debug"), { recursive: true });
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 //
-// workspace-1: fastedge-config.test.json in subdir, package.json at root
+// workspace-1: .fastedge-debug/ in subdir, package.json at root
 //
 //   tmp/
 //   ├── first-app/
 //   │   ├── index.js
-//   │   └── fastedge-config.test.json
+//   │   └── .fastedge-debug/
 //   ├── second-app/
 //   │   ├── index.js
-//   │   └── fastedge-config.test.json
+//   │   └── .fastedge-debug/
 //   └── package.json
 //
-// workspace-2/first-app: config and package.json at same level
+// workspace-2/first-app: .fastedge-debug/ and package.json at same level
 //
 //   tmp/
 //   ├── src/index.js
 //   ├── package.json
-//   └── fastedge-config.test.json
+//   └── .fastedge-debug/
 //
-// workspace-2/second-app: config inside src/, package.json one level up
+// workspace-2/second-app: .fastedge-debug/ inside src/, package.json one level up
 //
 //   tmp/
 //   ├── src/
 //   │   ├── index.js
-//   │   └── fastedge-config.test.json
+//   │   └── .fastedge-debug/
 //   └── package.json
 //
-// workspace-2/third-app: no config file, package.json at root (auto-create case)
+// workspace-2/third-app: no .fastedge-debug/, package.json at root (auto-create case)
 //
 //   tmp/
 //   ├── src/index.js
@@ -68,9 +72,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("resolveConfigRoot", () => {
-  it("returns the dir containing fastedge-config.test.json (workspace-1 first-app)", () => {
+  it("returns the dir containing .fastedge-debug/ (workspace-1 first-app)", () => {
     const configDir = path.join(tmp, "first-app");
-    touch(path.join(configDir, "fastedge-config.test.json"));
+    mkDebugDir(configDir);
     touch(path.join(configDir, "index.js"));
     touch(path.join(tmp, "package.json"));
 
@@ -78,26 +82,26 @@ describe("resolveConfigRoot", () => {
     expect(result).toBe(configDir);
   });
 
-  it("returns the dir containing fastedge-config.test.json (workspace-2/second-app — config in src/)", () => {
+  it("returns the dir containing .fastedge-debug/ (workspace-2/second-app — debug dir in src/)", () => {
     const srcDir = path.join(tmp, "src");
     touch(path.join(srcDir, "index.js"));
-    touch(path.join(srcDir, "fastedge-config.test.json"));
+    mkDebugDir(srcDir);
     touch(path.join(tmp, "package.json"));
 
     const result = resolveConfigRoot(path.join(srcDir, "index.js"));
     expect(result).toBe(srcDir);
   });
 
-  it("returns the dir when config and package.json are at the same level (workspace-2/first-app)", () => {
+  it("returns the dir when .fastedge-debug/ and package.json are at the same level (workspace-2/first-app)", () => {
     touch(path.join(tmp, "src", "index.js"));
     touch(path.join(tmp, "package.json"));
-    touch(path.join(tmp, "fastedge-config.test.json"));
+    mkDebugDir(tmp);
 
     const result = resolveConfigRoot(path.join(tmp, "src", "index.js"));
     expect(result).toBe(tmp);
   });
 
-  it("returns null when no fastedge-config.test.json exists (third-app)", () => {
+  it("returns null when no .fastedge-debug/ exists (third-app)", () => {
     touch(path.join(tmp, "src", "index.js"));
     touch(path.join(tmp, "package.json"));
 
@@ -111,7 +115,7 @@ describe("resolveConfigRoot", () => {
   });
 
   it("works when startPath is a directory", () => {
-    touch(path.join(tmp, "fastedge-config.test.json"));
+    mkDebugDir(tmp);
     const result = resolveConfigRoot(tmp);
     expect(result).toBe(tmp);
   });
@@ -122,36 +126,36 @@ describe("resolveConfigRoot", () => {
 // ---------------------------------------------------------------------------
 
 describe("resolveBuildRoot", () => {
-  it("returns workspace root package.json dir (workspace-1: config in subdir)", () => {
+  it("returns workspace root package.json dir (workspace-1: debug dir in subdir)", () => {
     const appDir = path.join(tmp, "first-app");
     touch(path.join(appDir, "index.js"));
-    touch(path.join(appDir, "fastedge-config.test.json"));
+    mkDebugDir(appDir);
     touch(path.join(tmp, "package.json"));
 
     const result = resolveBuildRoot(path.join(appDir, "index.js"));
     expect(result).toBe(tmp);
   });
 
-  it("returns the nearest package.json dir (workspace-2/first-app: same level as config)", () => {
+  it("returns the nearest package.json dir (workspace-2/first-app: same level as debug dir)", () => {
     touch(path.join(tmp, "src", "index.js"));
     touch(path.join(tmp, "package.json"));
-    touch(path.join(tmp, "fastedge-config.test.json"));
+    mkDebugDir(tmp);
 
     const result = resolveBuildRoot(path.join(tmp, "src", "index.js"));
     expect(result).toBe(tmp);
   });
 
-  it("returns the correct build root when config is deeper than package.json (workspace-2/second-app)", () => {
+  it("returns the correct build root when debug dir is deeper than package.json (workspace-2/second-app)", () => {
     const srcDir = path.join(tmp, "src");
     touch(path.join(srcDir, "index.js"));
-    touch(path.join(srcDir, "fastedge-config.test.json"));
+    mkDebugDir(srcDir);
     touch(path.join(tmp, "package.json"));
 
     const result = resolveBuildRoot(path.join(srcDir, "index.js"));
     expect(result).toBe(tmp);
   });
 
-  it("returns the build root for third-app (no config file)", () => {
+  it("returns the build root for third-app (no debug dir)", () => {
     touch(path.join(tmp, "src", "index.js"));
     touch(path.join(tmp, "package.json"));
 
@@ -176,37 +180,38 @@ describe("resolveBuildRoot", () => {
 });
 
 // ---------------------------------------------------------------------------
-// ensureConfigFile
+// ensureDebugDir
 // ---------------------------------------------------------------------------
 
-describe("ensureConfigFile", () => {
-  it("creates fastedge-config.test.json with {} when it does not exist", () => {
-    ensureConfigFile(tmp);
+describe("ensureDebugDir", () => {
+  it("creates .fastedge-debug/ directory when it does not exist", () => {
+    ensureDebugDir(tmp);
 
-    const filePath = path.join(tmp, "fastedge-config.test.json");
-    expect(fs.existsSync(filePath)).toBe(true);
-    expect(fs.readFileSync(filePath, "utf8")).toBe("{}");
+    const dirPath = path.join(tmp, ".fastedge-debug");
+    expect(fs.existsSync(dirPath)).toBe(true);
+    expect(fs.statSync(dirPath).isDirectory()).toBe(true);
   });
 
-  it("does not overwrite an existing fastedge-config.test.json", () => {
-    const filePath = path.join(tmp, "fastedge-config.test.json");
-    const existing = '{"type":"cdn"}';
-    fs.writeFileSync(filePath, existing, "utf8");
+  it("is a no-op when .fastedge-debug/ already exists", () => {
+    const dirPath = path.join(tmp, ".fastedge-debug");
+    fs.mkdirSync(dirPath);
+    // Place a file inside to verify it's not wiped
+    fs.writeFileSync(path.join(dirPath, "app.wasm"), "fake", "utf8");
 
-    ensureConfigFile(tmp);
+    ensureDebugDir(tmp);
 
-    expect(fs.readFileSync(filePath, "utf8")).toBe(existing);
+    expect(fs.existsSync(path.join(dirPath, "app.wasm"))).toBe(true);
   });
 
-  it("after ensureConfigFile at activeFile dir, resolveConfigRoot finds that dir", () => {
-    // Simulates the third-app flow: no config found, so we create one
+  it("after ensureDebugDir at activeFile dir, resolveConfigRoot finds that dir", () => {
+    // Simulates the third-app flow: no debug dir found, so we create one
     // co-located with the active file (not at the build root).
     const srcDir = path.join(tmp, "src");
     touch(path.join(srcDir, "index.js"));
     touch(path.join(tmp, "package.json")); // build root is tmp, not srcDir
 
-    // Caller places config next to the active file
-    ensureConfigFile(srcDir);
+    // Caller creates debug dir next to the active file
+    ensureDebugDir(srcDir);
 
     const result = resolveConfigRoot(path.join(srcDir, "index.js"));
     expect(result).toBe(srcDir);  // srcDir, not tmp
@@ -221,7 +226,7 @@ describe("config root vs build root split (workspace-1)", () => {
   it("configRoot is the app subdir, buildRoot is the workspace root", () => {
     const appDir = path.join(tmp, "first-app");
     touch(path.join(appDir, "index.js"));
-    touch(path.join(appDir, "fastedge-config.test.json"));
+    mkDebugDir(appDir);
     touch(path.join(tmp, "package.json"));
 
     const activeFile = path.join(appDir, "index.js");
@@ -233,9 +238,9 @@ describe("config root vs build root split (workspace-1)", () => {
     const firstApp = path.join(tmp, "first-app");
     const secondApp = path.join(tmp, "second-app");
     touch(path.join(firstApp, "index.js"));
-    touch(path.join(firstApp, "fastedge-config.test.json"));
+    mkDebugDir(firstApp);
     touch(path.join(secondApp, "index.js"));
-    touch(path.join(secondApp, "fastedge-config.test.json"));
+    mkDebugDir(secondApp);
     touch(path.join(tmp, "package.json"));
 
     expect(resolveConfigRoot(path.join(firstApp, "index.js"))).toBe(firstApp);

--- a/src/utils/resolveAppRoot.ts
+++ b/src/utils/resolveAppRoot.ts
@@ -10,17 +10,17 @@ function startDir(startPath: string): string {
 }
 
 /**
- * Walk up from a file (or directory) path to find the per-app config root.
+ * Walk up from a file (or directory) path to find the per-app debug root.
  *
- * Returns the first directory containing `fastedge-config.test.json`, or null
- * if none is found. This is the anchor for per-app identity (.debug-port sidecar,
- * WORKSPACE_PATH passed to the debugger server).
+ * Returns the first directory containing a `.fastedge-debug/` folder, or null
+ * if none is found. This is the anchor for per-app identity (.debug-port,
+ * app.wasm, config — all inside `.fastedge-debug/`).
  */
 export function resolveConfigRoot(startPath: string): string | null {
   let dir = startDir(startPath);
 
   while (true) {
-    if (fs.existsSync(path.join(dir, "fastedge-config.test.json"))) {
+    if (fs.existsSync(path.join(dir, ".fastedge-debug"))) {
       return dir;
     }
     const parent = path.dirname(dir);
@@ -53,18 +53,15 @@ export function resolveBuildRoot(startPath: string): string | null {
 }
 
 /**
- * Ensure a minimal `fastedge-config.test.json` exists in the given directory.
+ * Ensure the `.fastedge-debug/` directory exists in the given directory.
  *
- * Used when no config file is found during root resolution (the "third-app" case —
- * a project with only a package.json / Cargo.toml and no per-app config yet).
- * Writing `{}` creates the anchor that isolates this app's debug port from others
- * in the same workspace without making any assumptions about app configuration.
+ * Used when no debug root is found during resolution (the "third-app" case —
+ * a project with only a package.json / Cargo.toml and no per-app debug dir yet).
+ * Creating the directory establishes the anchor that isolates this app's debug
+ * artifacts from others in the same workspace.
  *
- * No-op if the file already exists.
+ * No-op if the directory already exists (recursive mkdir).
  */
-export function ensureConfigFile(dir: string): void {
-  const configPath = path.join(dir, "fastedge-config.test.json");
-  if (!fs.existsSync(configPath)) {
-    fs.writeFileSync(configPath, "{}", "utf8");
-  }
+export function ensureDebugDir(dir: string): void {
+  fs.mkdirSync(path.join(dir, ".fastedge-debug"), { recursive: true });
 }

--- a/src/utils/resolveAppRoot.ts
+++ b/src/utils/resolveAppRoot.ts
@@ -20,8 +20,12 @@ export function resolveConfigRoot(startPath: string): string | null {
   let dir = startDir(startPath);
 
   while (true) {
-    if (fs.existsSync(path.join(dir, ".fastedge-debug"))) {
-      return dir;
+    try {
+      if (fs.statSync(path.join(dir, ".fastedge-debug")).isDirectory()) {
+        return dir;
+      }
+    } catch {
+      // .fastedge-debug doesn't exist in this directory — continue walking up
     }
     const parent = path.dirname(dir);
     if (parent === dir) return null;
@@ -63,5 +67,19 @@ export function resolveBuildRoot(startPath: string): string | null {
  * No-op if the directory already exists (recursive mkdir).
  */
 export function ensureDebugDir(dir: string): void {
-  fs.mkdirSync(path.join(dir, ".fastedge-debug"), { recursive: true });
+  const debugPath = path.join(dir, ".fastedge-debug");
+  try {
+    if (!fs.statSync(debugPath).isDirectory()) {
+      throw new Error(
+        `Cannot create debug directory: "${debugPath}" already exists as a file. ` +
+          "Remove or rename it and try again.",
+      );
+    }
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      fs.mkdirSync(debugPath, { recursive: true });
+    } else {
+      throw err;
+    }
+  }
 }


### PR DESCRIPTION
This enables partial config files as test fixtures in our sdk example folders